### PR TITLE
improvement(ng-mobx-export):export module name as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ $ npm install --save ng-mobx
 
 Import ng-mobx and include the module:
 ```
-import 'ng-mobx';
+import ngMobx from 'ng-mobx';
 
 angular.module('app', [
   ...
-  'ng-mobx',
+  ngMobx,
   ...
 ]);
 ```

--- a/lib/ng-mobx.js
+++ b/lib/ng-mobx.js
@@ -1,15 +1,13 @@
 import angular from 'angular';
 import mobx from 'mobx';
 
-const wrappedFunctions = {};
+export const wrappedFunctions = {};
 ['autorun', 'autorunAsync', 'reaction', 'when'].forEach((fnName) => {
   wrappedFunctions[fnName] =   (scope, ...args) => {
     const dispose = mobx[fnName](...args);
     if (scope) scope.$on('$destroy', dispose);
   }
 });
-
-export default wrappedFunctions;
 
 const mobxAutorun = ['$timeout', function mobxAutorun($timeout) {
   return {
@@ -26,4 +24,4 @@ const mobxAutorun = ['$timeout', function mobxAutorun($timeout) {
 }];
 
 const ngMobxModule = angular.module('ng-mobx', []);
-ngMobxModule.directive('mobxAutorun', mobxAutorun);
+export default ngMobxModule.directive('mobxAutorun', mobxAutorun).name;


### PR DESCRIPTION
export module name as default so that caller no longer need to care about the real module name