### PR TITLE
ready for v1.5.0 publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,0 @@
-/.gitignore
-/.travis.yml
-/example
-/lib
-/spec
-/tsconfig.json
-/webpack.config.js
-/yarn.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: node_js
 node_js:
-  - "8"
+  - 8
+cache:
+  directories:
+    - node_modules
+script:
+  - npm test

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ Use CDN and include:
 
 ```html
 <!-- development -->
-<script src="https://unpkg.com/mobx-angularjs@1.5.0/dist/mobx-angularjs.js"></script>
+<script src="https://unpkg.com/mobx-angularjs/mobx-angularjs.js"></script>
 
 <!-- production -->
-<script src="https://unpkg.com/mobx-angularjs@1.5.0/dist/mobx-angularjs.min.js"></script>
+<script src="https://unpkg.com/mobx-angularjs/mobx-angularjs.min.js"></script>
 ```
 
 ```js

--- a/example/node_modules/mobx-angularjs/index.js
+++ b/example/node_modules/mobx-angularjs/index.js
@@ -1,2 +1,2 @@
-export * from '../../../lib/mobx-angularjs.ts'
-export { default } from '../../../lib/mobx-angularjs.ts'
+export * from '../../../src'
+export { default } from '../../../src'

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "mobx-angularjs",
   "version": "1.5.0",
   "description": "AngularJS connector to MobX",
-  "main": "mobx-angularjs.umd.js",
-  "typings": "mobx-angularjs.d.ts",
+  "main": "mobx-angularjs.js",
+  "typings": "index.d.ts",
   "author": "Adam Klein",
   "contributors": [
     "Nick Breaton",
@@ -26,7 +26,7 @@
   ],
   "scripts": {
     "prebuild": "rimraf dist/*",
-    "build": "npm run prebuild && webpack --env.type=umd && webpack --env.type=global && webpack -p --env.type=global.min",
+    "build": "npm run prebuild && webpack --env.type=umd && webpack -p --env.type=umd.min",
     "example": "parcel example/index.html -o --no-cache --no-hmr -d node_modules/.example",
     "pub": "npm test && npm run build && cp {README.md,package.json} dist && npm publish dist",
     "test": "jest"

--- a/package.json
+++ b/package.json
@@ -2,9 +2,13 @@
   "name": "mobx-angularjs",
   "version": "1.5.0",
   "description": "AngularJS connector to MobX",
-  "main": "dist/mobx-angularjs.umd.js",
-  "typings": "dist/mobx-angularjs.d.ts",
+  "main": "mobx-angularjs.umd.js",
+  "typings": "mobx-angularjs.d.ts",
   "author": "Adam Klein",
+  "contributors": [
+    "Nick Breaton",
+    "Kuitos"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -22,8 +26,9 @@
   ],
   "scripts": {
     "prebuild": "rimraf dist/*",
-    "build": "webpack --env.type=umd && webpack --env.type=global && webpack -p --env.type=global.min",
+    "build": "npm run prebuild && webpack --env.type=umd && webpack --env.type=global && webpack -p --env.type=global.min",
     "example": "parcel example/index.html -o --no-cache --no-hmr -d node_modules/.example",
+    "pub": "npm test && npm run build && cp {README.md,package.json} dist && npm publish dist",
     "test": "jest"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "scripts": {
     "prebuild": "rimraf dist/*",
-    "build": "npm run prebuild && webpack --env.type=umd && webpack -p --env.type=umd.min",
+    "build": "webpack --env.type=umd && webpack -p --env.type=umd.min",
     "example": "parcel example/index.html -o --no-cache --no-hmr -d node_modules/.example",
     "pub": "npm test && npm run build && cp {README.md,package.json} dist && npm publish dist",
     "test": "jest"

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -1,6 +1,6 @@
 import { Count } from './fixtures/count-store'
 import * as angular from 'angular'
-import * as mobxAngular from '../lib/mobx-angularjs'
+import mobxAngular from '../src/index'
 
 import 'angular-mocks'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ const link: angular.IDirectiveLinkFn = ($scope) => {
     () => [...$$watchers].map(watcher => watcher.get($scope)),
     () => setTimeout($scope.$digest.bind($scope))
   )
-  
+
   $scope.$on('$destroy', dispose)
 }
 
@@ -20,4 +20,4 @@ app.directive('mobxAutorun', () => ({
   link
 }))
 
-export default module.exports = app.name
+export default app.name

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ const link: angular.IDirectiveLinkFn = ($scope) => {
 
   const dispose = reaction(
     () => [...$$watchers].map(watcher => watcher.get($scope)),
-    () => setTimeout($scope.$digest.bind($scope))
+    () => !$scope.$$phase && $scope.$digest()
   )
 
   $scope.$on('$destroy', dispose)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,6 @@
     "experimentalDecorators": true
   },
   "files": [
-    "lib/mobx-angularjs.ts"
+    "src/index.ts"
   ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,8 +4,8 @@ const name = 'mobx-angularjs'
 
 module.exports = ({ type }) => {
   const config = {
-    context: resolve(__dirname, 'lib'),
-    entry: './mobx-angularjs.ts',
+    context: resolve(__dirname, 'src'),
+    entry: './index.ts',
     module: {
       rules: [
         { 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,15 +27,11 @@ module.exports = ({ type }) => {
   switch (type) {
     case 'umd':
       config.output.libraryTarget = 'umd'
-      config.output.filename = `${name}.umd.js`
-      break
-    case 'global':
-      config.output.libraryTarget = 'jsonp'
       config.output.filename = `${name}.js`
       config.devtool = 'inline-source-map'
       break
-    case 'global.min':
-      config.output.libraryTarget = 'jsonp'
+    case 'umd.min':
+      config.output.libraryTarget = 'umd'
       config.output.filename = `${name}.min.js`
       break
   }


### PR DESCRIPTION
major changes
1. renaming dir name and file name according to community usual practice
2. change to sync digest for avoiding the ambiguous of when the view model updated
3. fix weird module export `export default module.exports = app.name`
4. use `npm run pub` to publish package
5. remove unnecessary build library target